### PR TITLE
[SPIP] fix: use event instead of event.event in setFileName

### DIFF
--- a/d2-tracker/dhis2.angular.services.js
+++ b/d2-tracker/dhis2.angular.services.js
@@ -495,10 +495,10 @@ var d2Services = angular.module('d2Services', ['ngResource'])
         var fileNames = CurrentSelection.getFileNames() || {};
         FileService.get(valueId).then(function(response){
             if(response && response.displayName){
-                if(!fileNames[event.event]){
-                    fileNames[event.event] = {};
+                if(!fileNames[event]){
+                    fileNames[event] = {};
                 }
-                fileNames[event.event][dataElementId] = response.displayName;
+                fileNames[event][dataElementId] = response.displayName;
                 CurrentSelection.setFileNames( fileNames );
             }
         });


### PR DESCRIPTION
Required by https://app.clickup.com/t/86955xy5e

- `dhis2.angular.services.js -> setFileName(event, ...)`, used only for dataElement.valueType == "FILE_RESOURCE", does `event.event`, but `event` is already a string, so `event.event` results in `undefined`. 

- [x] Deployed to https://platform.samaritanspurse.org/